### PR TITLE
docs: added file hyperlink to 'LICENCE.md' with British spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ WIP
 
 ## License
 
-Distributed under the GNU General Public License v3. See LICENSE.md for more information
+Distributed under the GNU General Public License v3. See [LICENCE.md](/LICENCE.md) for more information
 
 ## Contact
 


### PR DESCRIPTION
Added a link to the `LICENCE.md` file in the README.
Renamed the reference to use the British spelling of 'licence'.